### PR TITLE
Allow the caller to force the recomputation of the version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,37 @@
 /*
  */
 
-var hash;
+var githash;
 var exec = require('child_process').exec;
-exports.version = function(major, minor, cb) {
-  if (hash) {
-    cb (null, hash);
+
+/**
+ * Generate the formatted key given the major, minor and hash versions.
+ * @param {number|string} major
+ * @param {number|string} minor
+ * @param {string} githash
+ *
+ * @param {string} the version key
+ */ 
+var _makeKey = function (major, minor, githash) {
+  return [major, minor, githash.replace(/\s/g, '')].join('.');
+};
+
+/**
+ * Generate a version number that encodes the git hash.
+ *
+ * @param {number|string} major
+ * @param {number|string} minor
+ * @param {function (error, string)} cb - callback with the result
+ * @param {boolean=false} force - force the recomputation of the git hash
+ */
+exports.version = function(major, minor, cb, force) {
+  if (githash && force !== true) {
+    cb(null, _makeKey(major, minor, githash));
   } else {
-    var child = exec('git rev-parse --short HEAD', {cwd: __dirname} ,
+    var child = exec('git rev-parse --short HEAD', {cwd: __dirname},
       function (error, stdout, stderr) {
-        hash = [major, minor, stdout.replace(/\s/g, '')].join('.');
-        cb(error, hash);
-      });
+        cb(error, _makeKey(major, minor, stdout));
+      }
+    );
   }
 };


### PR DESCRIPTION
The flag is added to permit users to always get the latest version.
This is important in scenarios where a server is monitoring a file
system and automatically reloading when the contents change. With
the force flag, the server can ensure it has the latest version
of the git hash.
